### PR TITLE
Readme updated, return code check added for api call

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,17 @@ Send a message to a Slack Channel
 * `channel` - The channel name of the Slack Channel (without the #).
 * `subdomain` - The slack subdomain.
 
+You can create a slack token by going to the account page on your slack domain:
+`<your-subdomain>.slack.com/services` and click 'add New Integration' and select
+'incoming webhooks'. Copy your token (as can be found in the example curl
+command) and don't forget to click 'Add Integration'.
+
+This token can be used directly in the wercker.yml (not
+recommended) or better: as an environment variable. You can add environment
+variables to wercker, by going to the settings tab of your application.
+In the `pipeline` section you can add environment variables. You can use
+those environment variables in the wercker.yml just as you would normally
+in a shell script (with a dollar sign in front of it).
 
 Example
 --------
@@ -51,4 +62,5 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ## 0.0.4
 - updated documentation
-- check for surplus hash in channel argument
+- check for redundant hash in channel argument
+- tests added

--- a/readme.md
+++ b/readme.md
@@ -7,8 +7,8 @@ Send a message to a Slack Channel
 ### required
 
 * `token` - Your Slack token.
-* `channel` - The channel name of the Slack Channel
-* `subdomain` - The Campfire subdomain.
+* `channel` - The channel name of the Slack Channel (without the #).
+* `subdomain` - The slack subdomain.
 
 
 Example

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ Add SLACK_TOKEN as deploy target or application environment variable.
 
     build:
         after-steps:
-            - slack-notify:
+            - sherzberg/slack-notify:
                 subdomain: slacksubdomain
                 token: $SLACK_TOKEN
                 channel: general
@@ -46,3 +46,9 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Changelog
+
+## 0.0.4
+- updated documentation
+- check for surplus hash in channel argument

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ ! -n "$WERCKER_SLACK_NOTIFY_SUBDOMAIN" ]; then
-error 'Please specify domain property'
+error 'Please specify the subdomain property'
   exit 1
 fi
 
@@ -11,7 +11,12 @@ error 'Please specify token property'
 fi
 
 if [ ! -n "$WERCKER_SLACK_NOTIFY_CHANNEL" ]; then
-error 'Please specify subdomain property'
+error 'Please specify a channel'
+  exit 1
+fi
+
+if [[ ! $WERCKER_SLACK_NOTIFY_CHANNEL == \#* ]]; then
+error "Please specify the channel without the '#'"
   exit 1
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -75,5 +75,5 @@ if [ "$RESULT" = "500" ]; then
 fi
 
 if [ "$RESULT" = "404" ]; then
-  fatal "Subdomain not found."
+  fatal "Subdomain or token not found."
 fi

--- a/run.sh
+++ b/run.sh
@@ -51,8 +51,8 @@ fi
 
 json="{\"channel\": \"#$WERCKER_SLACK_NOTIFY_CHANNEL\", \"text\": \"$WERCKER_SLACK_NOTIFY_MESSAGE\"}"
 
-RESULT=`curl -s -d "payload=$json" "https://$WERCKER_SLACK_NOTIFY_SUBDOMAIN.slack.com/services/hooks/incoming-webhook?token=$WERCKER_SLACK_NOTIFY_TOKEN" --output $WERCKER_STEP_TEMP/result.txt`
-echo $RESULT
+RESULT=`curl -s -d "payload=$json" "https://$WERCKER_SLACK_NOTIFY_SUBDOMAIN.slack.com/services/hooks/incoming-webhook?token=$WERCKER_SLACK_NOTIFY_TOKEN" --output $WERCKER_STEP_TEMP/result.txt -w "%{http_code}"`
+
 if [ "$RESULT" = "500" ]; then
   if grep -Fqx "No token" $WERCKER_STEP_TEMP/result.txt; then
     fatal "Specified token is invalid."
@@ -71,7 +71,7 @@ if [ "$RESULT" = "500" ]; then
   fi
 
   # Unhandled error
-  fatal <$WERCKER_STEP_TEMP/result.txt
+  # fatal <$WERCKER_STEP_TEMP/result.txt
 fi
 
 if [ "$RESULT" = "404" ]; then

--- a/run.sh
+++ b/run.sh
@@ -55,7 +55,7 @@ RESULT=`curl -s -d "payload=$json" "https://$WERCKER_SLACK_NOTIFY_SUBDOMAIN.slac
 
 if [ "$RESULT" = "500" ]; then
   if grep -Fqx "No token" $WERCKER_STEP_TEMP/result.txt; then
-    fatal "Specified token is invalid."
+    fatal "No token is specified."
   fi
 
   if grep -Fqx "No hooks" $WERCKER_STEP_TEMP/result.txt; then

--- a/run.sh
+++ b/run.sh
@@ -52,7 +52,7 @@ fi
 json="{\"channel\": \"#$WERCKER_SLACK_NOTIFY_CHANNEL\", \"text\": \"$WERCKER_SLACK_NOTIFY_MESSAGE\"}"
 
 RESULT=`curl -s -d "payload=$json" "https://$WERCKER_SLACK_NOTIFY_SUBDOMAIN.slack.com/services/hooks/incoming-webhook?token=$WERCKER_SLACK_NOTIFY_TOKEN" --output $WERCKER_STEP_TEMP/result.txt`
-
+echo $RESULT
 if [ "$RESULT" = "500" ]; then
   if grep -Fqx "No token" $WERCKER_STEP_TEMP/result.txt; then
     fatal "Specified token is invalid."

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ error 'Please specify a channel'
   exit 1
 fi
 
-if [[ ! $WERCKER_SLACK_NOTIFY_CHANNEL == \#* ]]; then
+if [[ $WERCKER_SLACK_NOTIFY_CHANNEL == \#* ]]; then
 error "Please specify the channel without the '#'"
   exit 1
 fi

--- a/tests/helper.sh
+++ b/tests/helper.sh
@@ -7,6 +7,7 @@ function fatal() {
   if [ "$FATAL_MESSAGE" = "$1" ]; then
     exit 0
   else
+    echo "Fatal error: called with $1 expected $FATAL_MESSAGE"
     exit 1
   fi
 }

--- a/tests/helper.sh
+++ b/tests/helper.sh
@@ -1,0 +1,5 @@
+function fatal() {
+  echo "fatal called with : $1"
+  exit
+}
+

--- a/tests/helper.sh
+++ b/tests/helper.sh
@@ -3,7 +3,7 @@
 # else
 function fatal() {
   echo "fatal called with : $1"
-  FATAL_CALLED=1
+  export FATAL_CALLED="true"
   if [ "$FATAL_MESSAGE" = "$1" ]; then
     exit 0
   else

--- a/tests/helper.sh
+++ b/tests/helper.sh
@@ -3,8 +3,8 @@
 # else
 function fatal() {
   echo "fatal called with : $1"
-  $FATAL_CALLED = 1
-  if [ $FATAL_MESSAGE == $1 ]; then
+  FATAL_CALLED=1
+  if [ "$FATAL_MESSAGE" = "$1" ]; then
     exit 0
   else
     exit 1

--- a/tests/helper.sh
+++ b/tests/helper.sh
@@ -5,6 +5,7 @@ function fatal() {
   echo "fatal called with : $1"
   export FATAL_CALLED="true"
   if [ "$FATAL_MESSAGE" = "$1" ]; then
+    echo "Exiting with 0"
     exit 0
   else
     echo "Fatal error: called with $1 expected $FATAL_MESSAGE"

--- a/tests/helper.sh
+++ b/tests/helper.sh
@@ -1,5 +1,4 @@
 function fatal() {
   echo "fatal called with : $1"
-  exit
+  exit 1
 }
-

--- a/tests/helper.sh
+++ b/tests/helper.sh
@@ -1,4 +1,8 @@
+# if declare -f fatal; then
+#   echo "skipping fatal definition: already defined"
+# else
 function fatal() {
   echo "fatal called with : $1"
-  exit 1
+  exit 0
 }
+# fi

--- a/tests/helper.sh
+++ b/tests/helper.sh
@@ -3,6 +3,11 @@
 # else
 function fatal() {
   echo "fatal called with : $1"
-  exit 0
+  $FATAL_CALLED = 1
+  if [ $FATAL_MESSAGE == $1 ]; then
+    exit 0
+  else
+    exit 1
+  fi
 }
 # fi

--- a/tests/test_channel_does_not_exist.sh
+++ b/tests/test_channel_does_not_exist.sh
@@ -8,10 +8,11 @@ export WERCKER_SLACK_NOTIFY_TOKEN="$1"
 export WERCKER_SLACK_NOTIFY_CHANNEL="productz"
 export WERCKER_STEP_TEMP=/tmp
 export FATAL_MESSAGE="Could not find specified channel for subdomain/token."
-export FATAL_CALLED=0
+export FATAL_CALLED="false"
 
 source run.sh
 
-if [ $FATAL_CALLED -eq 0 ]; then
+if [ "$FATAL_CALLED" = "false" ]; then
+    echo "Error: fatal is not called."
     exit 1
 fi

--- a/tests/test_channel_does_not_exist.sh
+++ b/tests/test_channel_does_not_exist.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+source tests/helper.sh
+set -e
+
+export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
+export WERCKER_SLACK_NOTIFY_TOKEN="$1"
+export WERCKER_SLACK_NOTIFY_CHANNEL="productz"
+export WERCKER_STEP_TEMP=/tmp/
+source run.sh
+

--- a/tests/test_channel_does_not_exist.sh
+++ b/tests/test_channel_does_not_exist.sh
@@ -6,6 +6,12 @@ set -e
 export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
 export WERCKER_SLACK_NOTIFY_TOKEN="$1"
 export WERCKER_SLACK_NOTIFY_CHANNEL="productz"
-export WERCKER_STEP_TEMP=/tmp/
+export WERCKER_STEP_TEMP=/tmp
+export FATAL_MESSAGE="Could not find specified channel for subdomain/token."
+export FATAL_CALLED=0
+
 source run.sh
 
+if [ $FATAL_CALLED eq 0 ]; then
+    exit 1
+fi

--- a/tests/test_channel_does_not_exist.sh
+++ b/tests/test_channel_does_not_exist.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source tests/helper.sh
-set -e
 
 export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
 export WERCKER_SLACK_NOTIFY_TOKEN="$1"

--- a/tests/test_channel_does_not_exist.sh
+++ b/tests/test_channel_does_not_exist.sh
@@ -12,6 +12,6 @@ export FATAL_CALLED=0
 
 source run.sh
 
-if [ $FATAL_CALLED eq 0 ]; then
+if [ $FATAL_CALLED -eq 0 ]; then
     exit 1
 fi

--- a/tests/test_channel_starts_with_hash.sh
+++ b/tests/test_channel_starts_with_hash.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source tests/helper.sh
+set -e
+
+export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
+export WERCKER_SLACK_NOTIFY_TOKEN=$1
+export WERCKER_SLACK_NOTIFY_CHANNEL="#product"
+export WERCKER_STEP_TEMP=/tmp/
+source run.sh

--- a/tests/test_channel_starts_with_hash.sh
+++ b/tests/test_channel_starts_with_hash.sh
@@ -8,10 +8,10 @@ export WERCKER_SLACK_NOTIFY_TOKEN="$1"
 export WERCKER_SLACK_NOTIFY_CHANNEL="#product"
 export WERCKER_STEP_TEMP=/tmp
 export FATAL_MESSAGE="Please specify token property"
-export FATAL_CALLED=0
+export FATAL_CALLED="false"
 source run.sh
 
-if [ $FATAL_CALLED -eq 0 ]; then
+if [ "$FATAL_CALLED" = "false" ]; then
+    echo "Error: fatal is not called."
     exit 1
 fi
-

--- a/tests/test_channel_starts_with_hash.sh
+++ b/tests/test_channel_starts_with_hash.sh
@@ -6,7 +6,7 @@ export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
 export WERCKER_SLACK_NOTIFY_TOKEN="$1"
 export WERCKER_SLACK_NOTIFY_CHANNEL="#product"
 export WERCKER_STEP_TEMP=/tmp
-export FATAL_MESSAGE="Please specify token property"
+export FATAL_MESSAGE="Please specify the channel without the '#'"
 export FATAL_CALLED="false"
 source run.sh
 

--- a/tests/test_channel_starts_with_hash.sh
+++ b/tests/test_channel_starts_with_hash.sh
@@ -11,7 +11,7 @@ export FATAL_MESSAGE="Please specify token property"
 export FATAL_CALLED=0
 source run.sh
 
-if [ $FATAL_CALLED eq 0 ]; then
+if [ $FATAL_CALLED -eq 0 ]; then
     exit 1
 fi
 

--- a/tests/test_channel_starts_with_hash.sh
+++ b/tests/test_channel_starts_with_hash.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source tests/helper.sh
-set -e
 
 export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
 export WERCKER_SLACK_NOTIFY_TOKEN="$1"

--- a/tests/test_channel_starts_with_hash.sh
+++ b/tests/test_channel_starts_with_hash.sh
@@ -4,7 +4,14 @@ source tests/helper.sh
 set -e
 
 export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
-export WERCKER_SLACK_NOTIFY_TOKEN=$1
+export WERCKER_SLACK_NOTIFY_TOKEN="$1"
 export WERCKER_SLACK_NOTIFY_CHANNEL="#product"
-export WERCKER_STEP_TEMP=/tmp/
+export WERCKER_STEP_TEMP=/tmp
+export FATAL_MESSAGE="Please specify token property"
+export FATAL_CALLED=0
 source run.sh
+
+if [ $FATAL_CALLED eq 0 ]; then
+    exit 1
+fi
+

--- a/tests/test_invalid_subdomain.sh
+++ b/tests/test_invalid_subdomain.sh
@@ -11,6 +11,6 @@ export FATAL_MESSAGE="Subdomain or token not found."
 export FATAL_CALLED=0
 source run.sh
 
-if [ $FATAL_CALLED eq 0 ]; then
+if [ $FATAL_CALLED -eq 0 ]; then
     exit 1
 fi

--- a/tests/test_invalid_subdomain.sh
+++ b/tests/test_invalid_subdomain.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+source tests/helper.sh
+set -e
+
+export WERCKER_SLACK_NOTIFY_SUBDOMAIN="werckerz"
+export WERCKER_SLACK_NOTIFY_TOKEN=$1
+export WERCKER_SLACK_NOTIFY_CHANNEL="product"
+export WERCKER_STEP_TEMP=/tmp/
+source run.sh
+

--- a/tests/test_invalid_subdomain.sh
+++ b/tests/test_invalid_subdomain.sh
@@ -8,9 +8,10 @@ export WERCKER_SLACK_NOTIFY_TOKEN=$1
 export WERCKER_SLACK_NOTIFY_CHANNEL="product"
 export WERCKER_STEP_TEMP=/tmp
 export FATAL_MESSAGE="Subdomain or token not found."
-export FATAL_CALLED=0
+export FATAL_CALLED="false"
 source run.sh
 
-if [ $FATAL_CALLED -eq 0 ]; then
+if [ "$FATAL_CALLED" = "false" ]; then
+    echo "Error: fatal is not called."
     exit 1
 fi

--- a/tests/test_invalid_subdomain.sh
+++ b/tests/test_invalid_subdomain.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source tests/helper.sh
-set -e
 
 export WERCKER_SLACK_NOTIFY_SUBDOMAIN="werckerz"
 export WERCKER_SLACK_NOTIFY_TOKEN=$1

--- a/tests/test_invalid_subdomain.sh
+++ b/tests/test_invalid_subdomain.sh
@@ -6,6 +6,11 @@ set -e
 export WERCKER_SLACK_NOTIFY_SUBDOMAIN="werckerz"
 export WERCKER_SLACK_NOTIFY_TOKEN=$1
 export WERCKER_SLACK_NOTIFY_CHANNEL="product"
-export WERCKER_STEP_TEMP=/tmp/
+export WERCKER_STEP_TEMP=/tmp
+export FATAL_MESSAGE="Subdomain or token not found."
+export FATAL_CALLED=0
 source run.sh
 
+if [ $FATAL_CALLED eq 0 ]; then
+    exit 1
+fi

--- a/tests/test_invalid_token.sh
+++ b/tests/test_invalid_token.sh
@@ -11,6 +11,6 @@ export FATAL_MESSAGE="Subdomain or token not found."
 export FATAL_CALLED=0
 source run.sh
 
-if [ $FATAL_CALLED eq 0 ]; then
+if [ $FATAL_CALLED -eq 0 ]; then
     exit 1
 fi

--- a/tests/test_invalid_token.sh
+++ b/tests/test_invalid_token.sh
@@ -7,4 +7,10 @@ export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
 export WERCKER_SLACK_NOTIFY_TOKEN="${1}z"
 export WERCKER_SLACK_NOTIFY_CHANNEL="product"
 export WERCKER_STEP_TEMP=/tmp
+export FATAL_MESSAGE="Subdomain or token not found."
+export FATAL_CALLED=0
 source run.sh
+
+if [ $FATAL_CALLED eq 0 ]; then
+    exit 1
+fi

--- a/tests/test_invalid_token.sh
+++ b/tests/test_invalid_token.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source tests/helper.sh
+set -e
+
+export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
+export WERCKER_SLACK_NOTIFY_TOKEN="${1}z"
+export WERCKER_SLACK_NOTIFY_CHANNEL="product"
+export WERCKER_STEP_TEMP=/tmp
+source run.sh

--- a/tests/test_invalid_token.sh
+++ b/tests/test_invalid_token.sh
@@ -8,9 +8,10 @@ export WERCKER_SLACK_NOTIFY_TOKEN="${1}z"
 export WERCKER_SLACK_NOTIFY_CHANNEL="product"
 export WERCKER_STEP_TEMP=/tmp
 export FATAL_MESSAGE="Subdomain or token not found."
-export FATAL_CALLED=0
+export FATAL_CALLED="false"
 source run.sh
 
-if [ $FATAL_CALLED -eq 0 ]; then
+if [ "$FATAL_CALLED" = "false" ]; then
+    echo "Error: fatal is not called."
     exit 1
 fi

--- a/tests/test_invalid_token.sh
+++ b/tests/test_invalid_token.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 source tests/helper.sh
-set -e
 
 export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
 export WERCKER_SLACK_NOTIFY_TOKEN="${1}z"

--- a/wercker.yml
+++ b/wercker.yml
@@ -2,29 +2,30 @@ box: wercker/default
 build:
   steps:
     - validate-wercker-step
-    - script:
-        name: Succesful notify
-        code: |
-          source ./tests/helper.sh
-          export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
-          export WERCKER_SLACK_NOTIFY_TOKEN=$CORRECT_SLACK_TOKEN
-          export WERCKER_SLACK_NOTIFY_CHANNEL="product"
-          source ./run.sh
+    # # The tests below need a valid slack token exposed as environment varialbe
+    # # CORRECT_SLACK_TOKEN
+    # - script:
+    #     name: Succesful notify
+    #     code: |
+    #       source ./tests/helper.sh
+    #       export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
+    #       export WERCKER_SLACK_NOTIFY_TOKEN=$CORRECT_SLACK_TOKEN
+    #       export WERCKER_SLACK_NOTIFY_CHANNEL="product"
+    #       source ./run.sh
 
-    - script:
-        name: Subdomain does not exist
-        code: |
-          ./tests/test_invalid_subdomain.sh $CORRECT_SLACK_TOKEN
-    - script:
-        name: Invalid token
-        code: |
-          ./tests/test_invalid_token.sh $CORRECT_SLACK_TOKEN
-    - script:
-        name: Channel does not exist
-        code: |
-          ./tests/test_channel_does_not_exist.sh
-
-    - script:
-        name: Channel starts with hash
-        code: |
-          ./tests/test_channel_starts_with_hash.sh
+    # - script:
+    #     name: Subdomain does not exist
+    #     code: |
+    #       ./tests/test_invalid_subdomain.sh $CORRECT_SLACK_TOKEN
+    # - script:
+    #     name: Invalid token
+    #     code: |
+    #       ./tests/test_invalid_token.sh $CORRECT_SLACK_TOKEN
+    # - script:
+    #     name: Channel does not exist
+    #     code: |
+    #       ./tests/test_channel_does_not_exist.sh
+    # - script:
+    #     name: Channel starts with hash
+    #     code: |
+    #       ./tests/test_channel_starts_with_hash.sh

--- a/wercker.yml
+++ b/wercker.yml
@@ -5,6 +5,11 @@ build:
     - script:
         name: Run the command once
         code: |
+          function fatal() {
+            echo "fatal called with : $1"
+            exit
+          }
+
           export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
           export WERCKER_SLACK_NOTIFY_TOKEN=$CORRECT_SLACK_TOKEN
           export WERCKER_SLACK_NOTIFY_CHANNEL="product"

--- a/wercker.yml
+++ b/wercker.yml
@@ -3,10 +3,46 @@ build:
   steps:
     - validate-wercker-step
     - script:
-        name: Run the command once
+        name: Succesful notify
         code: |
           source ./tests/helper.sh
           export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
           export WERCKER_SLACK_NOTIFY_TOKEN=$CORRECT_SLACK_TOKEN
           export WERCKER_SLACK_NOTIFY_CHANNEL="product"
+          source ./run.sh
+
+    - script:
+        name: Subdomain does not exist
+        code: |
+          source ./tests/helper.sh
+          export WERCKER_SLACK_NOTIFY_SUBDOMAIN="werckerz"
+          export WERCKER_SLACK_NOTIFY_TOKEN=$CORRECT_SLACK_TOKEN
+          export WERCKER_SLACK_NOTIFY_CHANNEL="product"
+          source ./run.sh
+
+    - script:
+        name: Invalid token
+        code: |
+          source ./tests/helper.sh
+          export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
+          export WERCKER_SLACK_NOTIFY_TOKEN="$CORRECT_SLACK_TOKENz"
+          export WERCKER_SLACK_NOTIFY_CHANNEL="product"
+          source ./run.sh
+
+    - script:
+        name: Channel does not exist
+        code: |
+          source ./tests/helper.sh
+          export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
+          export WERCKER_SLACK_NOTIFY_TOKEN="$CORRECT_SLACK_TOKEN"
+          export WERCKER_SLACK_NOTIFY_CHANNEL="productz"
+          source ./run.sh
+
+    - script:
+        name: Channel starts with hash
+        code: |
+          source ./tests/helper.sh
+          export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
+          export WERCKER_SLACK_NOTIFY_TOKEN="$CORRECT_SLACK_TOKEN"
+          export WERCKER_SLACK_NOTIFY_CHANNEL="#product"
           source ./run.sh

--- a/wercker.yml
+++ b/wercker.yml
@@ -5,11 +5,7 @@ build:
     - script:
         name: Run the command once
         code: |
-          function fatal() {
-            echo "fatal called with : $1"
-            exit
-          }
-
+          source ./tests/helper.sh
           export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
           export WERCKER_SLACK_NOTIFY_TOKEN=$CORRECT_SLACK_TOKEN
           export WERCKER_SLACK_NOTIFY_CHANNEL="product"

--- a/wercker.yml
+++ b/wercker.yml
@@ -16,16 +16,16 @@ build:
     # - script:
     #     name: Subdomain does not exist
     #     code: |
-    #       ./tests/test_invalid_subdomain.sh $CORRECT_SLACK_TOKEN
+    #       source ./tests/test_invalid_subdomain.sh $CORRECT_SLACK_TOKEN
     # - script:
     #     name: Invalid token
     #     code: |
-    #       ./tests/test_invalid_token.sh $CORRECT_SLACK_TOKEN
+    #       source ./tests/test_invalid_token.sh $CORRECT_SLACK_TOKEN
     # - script:
     #     name: Channel does not exist
     #     code: |
-    #       ./tests/test_channel_does_not_exist.sh
+    #       source ./tests/test_channel_does_not_exist.sh
     # - script:
     #     name: Channel starts with hash
     #     code: |
-    #       ./tests/test_channel_starts_with_hash.sh
+    #       source ./tests/test_channel_starts_with_hash.sh

--- a/wercker.yml
+++ b/wercker.yml
@@ -2,30 +2,30 @@ box: wercker/default
 build:
   steps:
     - validate-wercker-step
-    # # The tests below need a valid slack token exposed as environment varialbe
-    # # CORRECT_SLACK_TOKEN
-    # - script:
-    #     name: Succesful notify
-    #     code: |
-    #       source ./tests/helper.sh
-    #       export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
-    #       export WERCKER_SLACK_NOTIFY_TOKEN=$CORRECT_SLACK_TOKEN
-    #       export WERCKER_SLACK_NOTIFY_CHANNEL="product"
-    #       source ./run.sh
+    # The tests below need a valid slack token exposed as environment varialbe
+    # CORRECT_SLACK_TOKEN
+    - script:
+        name: Succesful notify
+        code: |
+          source ./tests/helper.sh
+          export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
+          export WERCKER_SLACK_NOTIFY_TOKEN=$CORRECT_SLACK_TOKEN
+          export WERCKER_SLACK_NOTIFY_CHANNEL="product"
+          source ./run.sh
 
-    # - script:
-    #     name: Subdomain does not exist
-    #     code: |
-    #       source ./tests/test_invalid_subdomain.sh $CORRECT_SLACK_TOKEN
-    # - script:
-    #     name: Invalid token
-    #     code: |
-    #       source ./tests/test_invalid_token.sh $CORRECT_SLACK_TOKEN
-    # - script:
-    #     name: Channel does not exist
-    #     code: |
-    #       source ./tests/test_channel_does_not_exist.sh
-    # - script:
-    #     name: Channel starts with hash
-    #     code: |
-    #       source ./tests/test_channel_starts_with_hash.sh
+    - script:
+        name: Subdomain does not exist
+        code: |
+          source ./tests/test_invalid_subdomain.sh $CORRECT_SLACK_TOKEN
+    - script:
+        name: Invalid token
+        code: |
+          source ./tests/test_invalid_token.sh $CORRECT_SLACK_TOKEN
+    - script:
+        name: Channel does not exist
+        code: |
+          source ./tests/test_channel_does_not_exist.sh $CORRECT_SLACK_TOKEN
+    - script:
+        name: Channel starts with hash
+        code: |
+          source ./tests/test_channel_starts_with_hash.sh $CORRECT_SLACK_TOKEN

--- a/wercker.yml
+++ b/wercker.yml
@@ -27,4 +27,4 @@ build:
     - script:
         name: Channel starts with hash
         code: |
-          ./tests/tests_channel_starts_with_hash.sh
+          ./tests/test_channel_starts_with_hash.sh

--- a/wercker.yml
+++ b/wercker.yml
@@ -6,6 +6,6 @@ build:
         name: Run the command once
         code: |
           export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
-          export WERCKER_SLACK_NOTIFY_TOKEN="some_token"
+          export WERCKER_SLACK_NOTIFY_TOKEN=$CORRECT_SLACK_TOKEN
           export WERCKER_SLACK_NOTIFY_CHANNEL="product"
           source ./run.sh

--- a/wercker.yml
+++ b/wercker.yml
@@ -2,30 +2,30 @@ box: wercker/default
 build:
   steps:
     - validate-wercker-step
-    # The tests below need a valid slack token exposed as environment varialbe
-    # CORRECT_SLACK_TOKEN
-    - script:
-        name: Succesful notify
-        code: |
-          source ./tests/helper.sh
-          export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
-          export WERCKER_SLACK_NOTIFY_TOKEN=$CORRECT_SLACK_TOKEN
-          export WERCKER_SLACK_NOTIFY_CHANNEL="product"
-          source ./run.sh
+    # # The tests below need a valid slack token exposed as environment varialbe
+    # # CORRECT_SLACK_TOKEN
+    # - script:
+    #     name: test: Succesful notify
+    #     code: |
+    #       source ./tests/helper.sh
+    #       export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
+    #       export WERCKER_SLACK_NOTIFY_TOKEN=$CORRECT_SLACK_TOKEN
+    #       export WERCKER_SLACK_NOTIFY_CHANNEL="product"
+    #       source ./run.sh
 
-    - script:
-        name: Subdomain does not exist
-        code: |
-          bash ./tests/test_invalid_subdomain.sh $CORRECT_SLACK_TOKEN
-    - script:
-        name: Invalid token
-        code: |
-          bash ./tests/test_invalid_token.sh $CORRECT_SLACK_TOKEN
-    - script:
-        name: Channel does not exist
-        code: |
-          bash ./tests/test_channel_does_not_exist.sh $CORRECT_SLACK_TOKEN
-    - script:
-        name: Channel starts with hash
-        code: |
-          bash ./tests/test_channel_starts_with_hash.sh $CORRECT_SLACK_TOKEN
+    # - script:
+    #     name: test: Subdomain does not exist
+    #     code: |
+    #       bash ./tests/test_invalid_subdomain.sh $CORRECT_SLACK_TOKEN
+    # - script:
+    #     name: test: Invalid token
+    #     code: |
+    #       bash ./tests/test_invalid_token.sh $CORRECT_SLACK_TOKEN
+    # - script:
+    #     name: test: Channel does not exist
+    #     code: |
+    #       bash ./tests/test_channel_does_not_exist.sh $CORRECT_SLACK_TOKEN
+    # - script:
+    #     name: test: Channel starts with hash
+    #     code: |
+    #       bash ./tests/test_channel_starts_with_hash.sh $CORRECT_SLACK_TOKEN

--- a/wercker.yml
+++ b/wercker.yml
@@ -16,16 +16,16 @@ build:
     - script:
         name: Subdomain does not exist
         code: |
-          source ./tests/test_invalid_subdomain.sh $CORRECT_SLACK_TOKEN
+          bash ./tests/test_invalid_subdomain.sh $CORRECT_SLACK_TOKEN
     - script:
         name: Invalid token
         code: |
-          source ./tests/test_invalid_token.sh $CORRECT_SLACK_TOKEN
+          bash ./tests/test_invalid_token.sh $CORRECT_SLACK_TOKEN
     - script:
         name: Channel does not exist
         code: |
-          source ./tests/test_channel_does_not_exist.sh $CORRECT_SLACK_TOKEN
+          bash ./tests/test_channel_does_not_exist.sh $CORRECT_SLACK_TOKEN
     - script:
         name: Channel starts with hash
         code: |
-          source ./tests/test_channel_starts_with_hash.sh $CORRECT_SLACK_TOKEN
+          bash ./tests/test_channel_starts_with_hash.sh $CORRECT_SLACK_TOKEN

--- a/wercker.yml
+++ b/wercker.yml
@@ -2,3 +2,10 @@ box: wercker/default
 build:
   steps:
     - validate-wercker-step
+    - script:
+        name: Run the command once
+        code: |
+          export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
+          export WERCKER_SLACK_NOTIFY_TOKEN="some_token"
+          export WERCKER_SLACK_NOTIFY_CHANNEL="product"
+          source ./run.sh

--- a/wercker.yml
+++ b/wercker.yml
@@ -25,7 +25,7 @@ build:
         code: |
           source ./tests/helper.sh
           export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
-          export WERCKER_SLACK_NOTIFY_TOKEN="$CORRECT_SLACK_TOKENz"
+          export WERCKER_SLACK_NOTIFY_TOKEN="${CORRECT_SLACK_TOKEN}z"
           export WERCKER_SLACK_NOTIFY_CHANNEL="product"
           source ./run.sh
 

--- a/wercker.yml
+++ b/wercker.yml
@@ -22,7 +22,7 @@ build:
     - script:
         name: Channel does not exist
         code: |
-          ./tests/test_channel_does_no_exist.sh
+          ./tests/test_channel_does_not_exist.sh
 
     - script:
         name: Channel starts with hash

--- a/wercker.yml
+++ b/wercker.yml
@@ -14,35 +14,17 @@ build:
     - script:
         name: Subdomain does not exist
         code: |
-          source ./tests/helper.sh
-          export WERCKER_SLACK_NOTIFY_SUBDOMAIN="werckerz"
-          export WERCKER_SLACK_NOTIFY_TOKEN=$CORRECT_SLACK_TOKEN
-          export WERCKER_SLACK_NOTIFY_CHANNEL="product"
-          source ./run.sh
-
+          ./tests/test_invalid_subdomain.sh $CORRECT_SLACK_TOKEN
     - script:
         name: Invalid token
         code: |
-          source ./tests/helper.sh
-          export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
-          export WERCKER_SLACK_NOTIFY_TOKEN="${CORRECT_SLACK_TOKEN}z"
-          export WERCKER_SLACK_NOTIFY_CHANNEL="product"
-          source ./run.sh
-
+          ./tests/test_invalid_token.sh $CORRECT_SLACK_TOKEN
     - script:
         name: Channel does not exist
         code: |
-          source ./tests/helper.sh
-          export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
-          export WERCKER_SLACK_NOTIFY_TOKEN="$CORRECT_SLACK_TOKEN"
-          export WERCKER_SLACK_NOTIFY_CHANNEL="productz"
-          source ./run.sh
+          ./tests/test_channel_does_no_exist.sh
 
     - script:
         name: Channel starts with hash
         code: |
-          source ./tests/helper.sh
-          export WERCKER_SLACK_NOTIFY_SUBDOMAIN="wercker"
-          export WERCKER_SLACK_NOTIFY_TOKEN="$CORRECT_SLACK_TOKEN"
-          export WERCKER_SLACK_NOTIFY_CHANNEL="#product"
-          source ./run.sh
+          ./tests/tests_channel_starts_with_hash.sh


### PR DESCRIPTION
In this pull request:
- there is some updated the documentation (describing how to get the slack token and add the environment variable to wercker)
- Code added that checks the return value from slack.
- some tests. You need to have an environment variable set to run it. So I've disabled them in the wercker.yml (to keep the build/pull request green).
